### PR TITLE
Modernize CMake, improve libnuma detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,7 @@ if(COMPILER_SUPPORTS_NOSIGNCOMP)
   add_definitions(-Wno-sign-compare)
 endif()
 
-
 add_definitions(-DCPP11THREADS -D_REENTRANT -U_OPENMP -Wno-unused-function -O3 -DNDEBUG -funroll-loops -std=c++1z -DMODE_KAFFPA -DPOINTER64=1 -DGIT_DESC=\"942944c\" )
-
-
 
 # check dependencies
 find_package(OpenMP REQUIRED)
@@ -84,8 +81,6 @@ endif()
   #add_definitions(${TBB_CXX_FLAGS})
 #endif()
 
-
-
 # 64 Bit option
 option(64BITMODE "64 bit mode" OFF)
 if(64BITMODE)
@@ -93,26 +88,11 @@ if(64BITMODE)
   add_definitions("-DPOINTER64=1")
 endif()
 
-
 # optimized output
 option(OPTIMIZED_OUTPUT "optimized output" OFF)
 if(OPTIMIZED_OUTPUT)
   add_definitions("-DKAFFPAOUTPUT")
 endif()
-
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/app)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/argtable3-3.0.3)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/io)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/tools)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/growt/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/ips4o)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/stats/include)
-
 
 set(LIBKAFFPA_SOURCE_FILES
   lib/data_structure/graph_hierarchy.cpp
@@ -184,46 +164,64 @@ set(LIBKAFFPA_SOURCE_FILES
   lib/partition/uncoarsening/refinement/parallel_kway_graph_refinement/kway_graph_refinement_core.cpp
   lib/partition/uncoarsening/parallel_uncoarsening.cpp
   extern/argtable3-3.0.3/argtable3.c)
+
 add_library(libmtkahip OBJECT ${LIBKAFFPA_SOURCE_FILES})
 
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/app)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/argtable3-3.0.3)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/io)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/growt/)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/ips4o)
+target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/stats/include)
+
+find_path(NUMA_INCLUDE_DIR numa.h)
+find_library(NUMA_LIBRARY numa REQUIRED)
+
+target_include_directories(libmtkahip PUBLIC ${NUMA_INCLUDE_DIR})
+target_link_libraries(libmtkahip PUBLIC ${NUMA_LIBRARY} ${OpenMP_CXX_LIBRARIES})
 
 # generate targets for each binary
-add_executable(mtkahip app/mtkahip.cpp $<TARGET_OBJECTS:libmtkahip>)
+add_executable(mtkahip app/mtkahip.cpp)
 target_compile_definitions(mtkahip PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(mtkahip ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl" "numa")
+target_link_libraries(mtkahip PRIVATE libmtkahip "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
 install(TARGETS mtkahip DESTINATION bin)
 
 # Shared interface library
-add_library(interfacemtkahip SHARED interface/mtkahip_interface.cpp $<TARGET_OBJECTS:libmtkahip>)
+add_library(interfacemtkahip SHARED interface/mtkahip_interface.cpp)
 target_include_directories(interfacemtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
 target_compile_definitions(interfacemtkahip PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(interfacemtkahip PUBLIC ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl" "numa")
+target_link_libraries(interfacemtkahip PUBLIC libmtkahip ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
 if(LIB_METIS)
         target_link_libraries(interface PUBLIC ${LIB_METIS})
 endif()
 install(TARGETS interfacemtkahip DESTINATION lib)
 
 # Static interface library
-add_library(interfacemtkahip_static interface/mtkahip_interface.cpp $<TARGET_OBJECTS:libmtkahip>)
+add_library(interfacemtkahip_static interface/mtkahip_interface.cpp)
 target_include_directories(interfacemtkahip_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
 target_compile_definitions(interfacemtkahip_static PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(interfacemtkahip_static PUBLIC ${OpenMP_CXX_LIBRARIES}  "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl" "numa")
+target_link_libraries(interfacemtkahip_static PUBLIC libmtkahip ${OpenMP_CXX_LIBRARIES}  "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
 set_target_properties(interfacemtkahip_static PROPERTIES PUBLIC_HEADER interface/mtkahip_interface.h)
 
-add_executable(graphchecker app/graphchecker.cpp $<TARGET_OBJECTS:libmtkahip>)
+add_executable(graphchecker app/graphchecker.cpp)
 target_compile_definitions(graphchecker PRIVATE "-DMODE_GRAPHCHECKER"  )
-target_link_libraries(graphchecker ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl" "numa")
+target_link_libraries(graphchecker libmtkahip ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
 install(TARGETS graphchecker DESTINATION bin)
 
-add_executable(evaluator app/evaluator.cpp $<TARGET_OBJECTS:libmtkahip>)
+add_executable(evaluator app/evaluator.cpp)
 target_compile_definitions(evaluator PRIVATE "-DMODE_EVALUATOR")
-target_link_libraries(evaluator ${OpenMP_CXX_LIBRARIES}  "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl" "numa")
+target_link_libraries(evaluator ${OpenMP_CXX_LIBRARIES} libmtkahip "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
 install(TARGETS evaluator DESTINATION bin)
 
-add_executable(interface_test misc/example_library_call/interface_test.cpp interface/mtkahip_interface.cpp $<TARGET_OBJECTS:libmtkahip> )
+add_executable(interface_test misc/example_library_call/interface_test.cpp interface/mtkahip_interface.cpp)
 target_include_directories(interface_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/interface)
 target_compile_definitions(interface_test PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(interface_test ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl" "numa")
+target_link_libraries(interface_test libmtkahip ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
 if(LIB_METIS)
         target_link_libraries(interface_test ${LIB_METIS})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,98 +1,62 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
+project(KaHIP LANGUAGES C CXX)
+
 include(CheckCXXCompilerFlag)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 find_program(CCACHE_PROGRAM ccache)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-
 if(CCACHE_PROGRAM)
-  message(STATUS "Using compiler cache")
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")
+  message(STATUS "Using compiler cache: ${CCACHE_PROGRAM}")
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()
-project(KaHIP C CXX)
 
-#add_definitions("-funroll-loops  -fno-stack-limit -std=c++1z -mcx16")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON) 
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# if no build mode is specified build in release mode
+# If no build mode is specified, build in Release mode.
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  set(CMAKE_BUILD_TYPE "Release")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
 
-# tweak compiler flags
-CHECK_CXX_COMPILER_FLAG(-funroll-loops COMPILER_SUPPORTS_FUNROLL_LOOPS)
-if(COMPILER_SUPPORTS_FUNROLL_LOOPS)
-  add_definitions(-funroll-loops)
-endif()
-CHECK_CXX_COMPILER_FLAG(-mcx16 COMPILER_SUPPORTS_MCX16)
-if(COMPILER_SUPPORTS_MCX16)
-  add_definitions(-mcx16)
-endif()
-#CHECK_CXX_COMPILER_FLAG(-std=c++1z COMPILER_SUPPORTS_CPP1Z)
-#if(COMPILER_SUPPORTS_CPP1Z)
-  #add_definitions(-std=c++1z)
-#endif()
-
-CHECK_CXX_COMPILER_FLAG(-Wno-unused-but-set-variable COMPILER_SUPPORTS_NOUSEDBUTSET)
-if(COMPILER_SUPPORTS_NOUSEDBUTSET)
-  add_definitions(-Wno-unused-but-set-variable)
-endif()
-
-CHECK_CXX_COMPILER_FLAG(-fno-stack-limit COMPILER_SUPPORTS_FNOSTACKLIMITS)
-if(COMPILER_SUPPORTS_FNOSTACKLIMITS)
-  add_definitions(-fno-stack-limit)
-endif()
-CHECK_CXX_COMPILER_FLAG(-Wall COMPILER_SUPPORTS_WALL)
-if(COMPILER_SUPPORTS_WALL)
-  add_definitions(-Wall)
-endif()
-CHECK_CXX_COMPILER_FLAG(-march=native COMPILER_SUPPORTS_MARCH_NATIVE)
-if(COMPILER_SUPPORTS_MARCH_NATIVE)
-  add_definitions(-march=native)
-endif()
-CHECK_CXX_COMPILER_FLAG(-fpermissive COMPILER_SUPPORTS_FPERMISSIVE)
-if(COMPILER_SUPPORTS_FPERMISSIVE)
-  add_definitions(-fpermissive)
-endif()
-CHECK_CXX_COMPILER_FLAG(-Wno-unused-result COMPILER_SUPPORTS_UNUSED)
-if(COMPILER_SUPPORTS_UNUSED)
-  add_definitions(-Wno-unused-result)
-endif()
-CHECK_CXX_COMPILER_FLAG(-Wno-sign-compare COMPILER_SUPPORTS_NOSIGNCOMP)
-if(COMPILER_SUPPORTS_NOSIGNCOMP)
-  add_definitions(-Wno-sign-compare)
-endif()
-
-add_definitions(-DCPP11THREADS -D_REENTRANT -U_OPENMP -Wno-unused-function -O3 -DNDEBUG -funroll-loops -std=c++1z -DMODE_KAFFPA -DPOINTER64=1 -DGIT_DESC=\"942944c\" )
-
-# check dependencies
-find_package(OpenMP REQUIRED)
-if(OpenMP_CXX_FOUND)
-  add_definitions(${OpenMP_CXX_FLAGS})
-endif()
-#find_package(TBB REQUIRED)
-#if(TBB_CXX_FOUND)
-  #add_definitions(${TBB_CXX_FLAGS})
-#endif()
-
-# 64 Bit option
 option(64BITMODE "64 bit mode" OFF)
-if(64BITMODE)
-  add_definitions("-DMODE64BITEDGES")
-  add_definitions("-DPOINTER64=1")
+option(OPTIMIZED_OUTPUT "optimized output" OFF)
+
+function(add_supported_cxx_option option_name)
+  string(MAKE_C_IDENTIFIER "${option_name}" option_id)
+  set(test_var "COMPILER_SUPPORTS_${option_id}")
+  check_cxx_compiler_flag("${option_name}" "${test_var}")
+  if(${test_var})
+    target_compile_options(mtkahip_obj PRIVATE "${option_name}")
+  endif()
+endfunction()
+
+# Check dependencies
+find_package(OpenMP REQUIRED)
+find_package(TBB QUIET COMPONENTS tbb tbbmalloc tbbmalloc_proxy)
+find_package(Threads REQUIRED)
+
+find_path(NUMA_INCLUDE_DIR NAMES numa.h)
+find_library(NUMA_LIBRARY NAMES numa REQUIRED)
+
+if(TBB_FOUND)
+  set(MTKAHIP_TBB_LIBS TBB::tbb TBB::tbbmalloc TBB::tbbmalloc_proxy)
+else()
+  set(MTKAHIP_TBB_LIBS tbb tbbmalloc tbbmalloc_proxy)
 endif()
 
-# optimized output
-option(OPTIMIZED_OUTPUT "optimized output" OFF)
-if(OPTIMIZED_OUTPUT)
-  add_definitions("-DKAFFPAOUTPUT")
-endif()
+set(MTKAHIP_COMMON_LIBS
+  OpenMP::OpenMP_CXX
+  ${NUMA_LIBRARY}
+  ${MTKAHIP_TBB_LIBS}
+  Threads::Threads
+  atomic
+  dl
+)
 
 set(LIBKAFFPA_SOURCE_FILES
   lib/data_structure/graph_hierarchy.cpp
@@ -163,75 +127,97 @@ set(LIBKAFFPA_SOURCE_FILES
   lib/partition/uncoarsening/refinement/parallel_kway_graph_refinement/multitry_kway_fm.cpp
   lib/partition/uncoarsening/refinement/parallel_kway_graph_refinement/kway_graph_refinement_core.cpp
   lib/partition/uncoarsening/parallel_uncoarsening.cpp
-  extern/argtable3-3.0.3/argtable3.c)
+  extern/argtable3-3.0.3/argtable3.c
+)
 
-add_library(libmtkahip OBJECT ${LIBKAFFPA_SOURCE_FILES})
+add_library(mtkahip_obj OBJECT ${LIBKAFFPA_SOURCE_FILES})
+target_include_directories(mtkahip_obj
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/app
+    ${CMAKE_CURRENT_SOURCE_DIR}/extern/argtable3-3.0.3
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/io
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools
+    ${CMAKE_CURRENT_SOURCE_DIR}/extern/growt
+    ${CMAKE_CURRENT_SOURCE_DIR}/extern/ips4o
+    ${CMAKE_CURRENT_SOURCE_DIR}/extern/stats/include
+    $<$<BOOL:${NUMA_INCLUDE_DIR}>:${NUMA_INCLUDE_DIR}>
+)
+target_compile_definitions(mtkahip_obj
+  PUBLIC
+    CPP11THREADS
+    _REENTRANT
+    MODE_KAFFPA
+    POINTER64=1
+    GIT_DESC="942944c"
+)
 
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/app)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/argtable3-3.0.3)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/io)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/growt/)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/ips4o)
-target_include_directories(libmtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern/stats/include)
+if(64BITMODE)
+  target_compile_definitions(mtkahip_obj PUBLIC MODE64BITEDGES POINTER64=1)
+endif()
 
-find_path(NUMA_INCLUDE_DIR numa.h)
-find_library(NUMA_LIBRARY numa REQUIRED)
+if(OPTIMIZED_OUTPUT)
+  target_compile_definitions(mtkahip_obj PUBLIC KAFFPAOUTPUT)
+endif()
 
-target_include_directories(libmtkahip PUBLIC ${NUMA_INCLUDE_DIR})
-target_link_libraries(libmtkahip PUBLIC ${NUMA_LIBRARY} ${OpenMP_CXX_LIBRARIES})
+add_supported_cxx_option(-funroll-loops)
+add_supported_cxx_option(-mcx16)
+add_supported_cxx_option(-Wno-unused-but-set-variable)
+add_supported_cxx_option(-fno-stack-limit)
+add_supported_cxx_option(-Wall)
+add_supported_cxx_option(-march=native)
+add_supported_cxx_option(-fpermissive)
+add_supported_cxx_option(-Wno-unused-result)
+add_supported_cxx_option(-Wno-sign-compare)
+add_supported_cxx_option(-Wno-unused-function)
 
 # generate targets for each binary
 add_executable(mtkahip app/mtkahip.cpp)
-target_compile_definitions(mtkahip PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(mtkahip PRIVATE libmtkahip "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
+target_compile_definitions(mtkahip PRIVATE MODE_KAFFPA)
+target_link_libraries(mtkahip PRIVATE mtkahip_obj ${MTKAHIP_COMMON_LIBS})
 install(TARGETS mtkahip DESTINATION bin)
 
 # Shared interface library
 add_library(interfacemtkahip SHARED interface/mtkahip_interface.cpp)
 target_include_directories(interfacemtkahip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
-target_compile_definitions(interfacemtkahip PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(interfacemtkahip PUBLIC libmtkahip ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
+target_compile_definitions(interfacemtkahip PRIVATE MODE_KAFFPA)
+target_link_libraries(interfacemtkahip PUBLIC mtkahip_obj ${MTKAHIP_COMMON_LIBS})
 if(LIB_METIS)
-        target_link_libraries(interface PUBLIC ${LIB_METIS})
+  target_link_libraries(interfacemtkahip PUBLIC ${LIB_METIS})
 endif()
 install(TARGETS interfacemtkahip DESTINATION lib)
 
 # Static interface library
-add_library(interfacemtkahip_static interface/mtkahip_interface.cpp)
+add_library(interfacemtkahip_static STATIC interface/mtkahip_interface.cpp)
 target_include_directories(interfacemtkahip_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
-target_compile_definitions(interfacemtkahip_static PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(interfacemtkahip_static PUBLIC libmtkahip ${OpenMP_CXX_LIBRARIES}  "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
+target_compile_definitions(interfacemtkahip_static PRIVATE MODE_KAFFPA)
+target_link_libraries(interfacemtkahip_static PUBLIC mtkahip_obj ${MTKAHIP_COMMON_LIBS})
 set_target_properties(interfacemtkahip_static PROPERTIES PUBLIC_HEADER interface/mtkahip_interface.h)
 
 add_executable(graphchecker app/graphchecker.cpp)
-target_compile_definitions(graphchecker PRIVATE "-DMODE_GRAPHCHECKER"  )
-target_link_libraries(graphchecker libmtkahip ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
+target_compile_definitions(graphchecker PRIVATE MODE_GRAPHCHECKER)
+target_link_libraries(graphchecker PRIVATE mtkahip_obj ${MTKAHIP_COMMON_LIBS})
 install(TARGETS graphchecker DESTINATION bin)
 
 add_executable(evaluator app/evaluator.cpp)
-target_compile_definitions(evaluator PRIVATE "-DMODE_EVALUATOR")
-target_link_libraries(evaluator ${OpenMP_CXX_LIBRARIES} libmtkahip "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
+target_compile_definitions(evaluator PRIVATE MODE_EVALUATOR)
+target_link_libraries(evaluator PRIVATE mtkahip_obj ${MTKAHIP_COMMON_LIBS})
 install(TARGETS evaluator DESTINATION bin)
 
 add_executable(interface_test misc/example_library_call/interface_test.cpp interface/mtkahip_interface.cpp)
 target_include_directories(interface_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/interface)
-target_compile_definitions(interface_test PRIVATE "-DMODE_KAFFPA")
-target_link_libraries(interface_test libmtkahip ${OpenMP_CXX_LIBRARIES} "tbb" "tbbmalloc" "tbbmalloc_proxy" "atomic" "dl")
+target_compile_definitions(interface_test PRIVATE MODE_KAFFPA)
+target_link_libraries(interface_test PRIVATE mtkahip_obj ${MTKAHIP_COMMON_LIBS})
 if(LIB_METIS)
-        target_link_libraries(interface_test ${LIB_METIS})
+  target_link_libraries(interface_test PRIVATE ${LIB_METIS})
 endif()
 install(TARGETS interface_test DESTINATION bin)
 
-install(TARGETS interfacemtkahip_static 
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        PUBLIC_HEADER DESTINATION include
-        )
-
-
-
+install(TARGETS interfacemtkahip_static
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  PUBLIC_HEADER DESTINATION include
+)

--- a/lib/definitions.h
+++ b/lib/definitions.h
@@ -11,6 +11,7 @@
 #include <limits>
 #include <queue>
 #include <vector>
+#include <cstdint>
 
 #include "limits.h"
 #include "macros_assertions.h"


### PR DESCRIPTION
I could not longer build mt-KaHIP on our servers since its CMake script couldn't locate libnuma. I fixed this by using Codex to modernize its CMake. Looks fine to be, building and installing still works. 